### PR TITLE
Local caching of Amazon S3 file operations

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -14,6 +14,8 @@
       <path value="$USER_HOME$/Sites/boot4" />
       <path value="$USER_HOME$/Sites/boot4/configuration.php" />
       <path value="$PROJECT_DIR$/vendor/composer" />
+      <path value="$PROJECT_DIR$/../../master/joomla4" />
+      <path value="/var/www/boot4/configuration.php" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.2" />

--- a/.idea/s3filesystem.iml
+++ b/.idea/s3filesystem.iml
@@ -2,7 +2,8 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/plugins/filesystem/s3/src" isTestSource="false" packagePrefix="Joomla\Plugin\Filesystem\S3" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Amazon S3 Filesystem for Joomla 1.0.2
 ================================================================================
 + Thumbnails caching on the local filesystem
++ Local caching of Amazon S3 file operations
 
 Amazon S3 Filesystem for Joomla 1.0.1
 ================================================================================

--- a/plugins/filesystem/s3/language/en-GB/plg_filesystem_s3.ini
+++ b/plugins/filesystem/s3/language/en-GB/plg_filesystem_s3.ini
@@ -75,6 +75,12 @@ PLG_FILESYSTEM_S3_CONFIG_STORAGE_CLASS_INTELLIGENT_TIERING="Intelligent Tiering"
 PLG_FILESYSTEM_S3_CONFIG_STORAGE_CLASS_GLACIER="Glacier (DANGER!)"
 PLG_FILESYSTEM_S3_CONFIG_STORAGE_CLASS_DEEP_ARCHIVE="Glacier Deep Archive (DANGER!)"
 
+PLG_FILESYSTEM_S3_CONFIG_CACHING_LABEL="Request caching"
+PLG_FILESYSTEM_S3_CONFIG_CACHING_DESC="Cache the directory listing requests to the Amazon S3 API to speed up the Media Manager display. However, any changes made outside of this site's Media Manager will not be reflected until the cache time lapses."
+
+PLG_FILESYSTEM_S3_CACHE_TIME_LABEL="Requests caching time"
+PLG_FILESYSTEM_S3_CACHE_TIME_DESC="The maximum time to cache requests to the Amazon S3 API. Recommended values are between 30 to 300 seconds. Shorter cache times may be ineffective, longer cache times could result in changes made outside of the Media Manager of this site not appearing for a very long time, leading to confusion. Default: 300 seconds (5 minutes)."
+
 [Configuration.Advanced]
 PLG_FILESYSTEM_S3_CONFIG_PREVIEW_LABEL="Image Preview"
 PLG_FILESYSTEM_S3_CONFIG_PREVIEW_DESC="When should I display image previews? <strong>WARNING! THIS MAY BE COSTLY!</strong> Enabling previews on S3 buckets without a CloudFront distribution may incur very increased costs since all images in a folder must be loaded from Amazon S3 every time you view that folder in the Media Manager."

--- a/plugins/filesystem/s3/s3.xml
+++ b/plugins/filesystem/s3/s3.xml
@@ -201,6 +201,29 @@
                             <option value="DEEP_ARCHIVE">PLG_FILESYSTEM_S3_CONFIG_STORAGE_CLASS_DEEP_ARCHIVE</option>
                             -->
                         </field>
+
+                        <field name="caching"
+                               type="radio"
+                               layout="joomla.form.field.radio.switcher"
+                               label="PLG_FILESYSTEM_S3_CONFIG_CACHING_LABEL"
+                               description="PLG_FILESYSTEM_S3_CONFIG_CACHING_DESC"
+                               default="0"
+                        >
+                            <option value="0">JNO</option>
+                            <option value="1">JYES</option>
+                        </field>
+
+                        <field name="cache_time"
+                               type="number"
+                               label="PLG_FILESYSTEM_S3_CACHE_TIME_LABEL"
+                               description="PLG_FILESYSTEM_S3_CACHE_TIME_DESC"
+                               default="300"
+                               min="10"
+                               max="31536000"
+                               validate="number"
+                               showon="caching:1"
+                        />
+
                     </form>
                     <!--
                         filter: alphanumeric integer no_html plaintext path

--- a/plugins/filesystem/s3/src/Adapter/S3Filesystem.php
+++ b/plugins/filesystem/s3/src/Adapter/S3Filesystem.php
@@ -10,6 +10,9 @@ namespace Joomla\Plugin\Filesystem\S3\Adapter;
 defined('_JEXEC') or die;
 
 use Exception;
+use Joomla\CMS\Cache\CacheController;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
+use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
@@ -248,6 +251,38 @@ class S3Filesystem implements AdapterInterface
 	private $tempFiles = [];
 
 	/**
+	 * Is caching of S3 requests enabled?
+	 *
+	 * @var   bool
+	 * @since 1.0.2
+	 */
+	private $cachingEnabled = false;
+
+	/**
+	 * Cache lifetime for S3 requests.
+	 *
+	 * @var   int
+	 * @since 1.0.2
+	 */
+	private $cacheLifetime = 300;
+
+	/**
+	 * The cache controller used to implement the S3 request caching.
+	 *
+	 * @var   CacheController|null
+	 * @since 1.0.2
+	 */
+	private $cacheController = null;
+
+	/**
+	 * The instance-specific salt to use for the callback cache controller.
+	 *
+	 * @var   string
+	 * @since 1.0.2
+	 */
+	private $cacheSalt;
+
+	/**
 	 * Private constructor
 	 *
 	 * @param   array  $setup
@@ -323,6 +358,9 @@ class S3Filesystem implements AdapterInterface
 
 		// Return the new S3 client instance
 		$this->connector = new Connector($configuration);
+
+		// Set up the hashing salt for the callback cache controller
+		$this->cacheSalt = md5(serialize($setup ?? []));
 	}
 
 	/**
@@ -417,6 +455,9 @@ class S3Filesystem implements AdapterInterface
 
 		$this->copyObject($this->bucket, $sourcePathAbsolute, $destinationPathAbsolute, Acl::ACL_PUBLIC_READ, $this->storageClass);
 
+		// Clear the cache for the destination folder
+		$this->uncacheDirectory(dirname($destinationPath) ?: '/');
+
 		return $destinationPath;
 	}
 
@@ -450,6 +491,9 @@ class S3Filesystem implements AdapterInterface
 
 		$this->connector->putObject($input, $this->bucket, $directory . $name, Acl::ACL_PUBLIC_READ, $headers);
 
+		// Clear the cache for the path where the file was created in
+		$this->uncacheDirectory($path);
+
 		return $name;
 	}
 
@@ -479,6 +523,9 @@ class S3Filesystem implements AdapterInterface
 
 		$this->connector->putObject($input, $this->bucket, $directory . $name . '/', Acl::ACL_PUBLIC_READ);
 
+		// Clear the cache for the path where the folder was created in
+		$this->uncacheDirectory($path);
+
 		return $name;
 	}
 
@@ -495,6 +542,9 @@ class S3Filesystem implements AdapterInterface
 	public function delete(string $path)
 	{
 		$info = $this->getFile($path);
+
+		// Clear the cache for the parent path
+		$this->uncacheDirectory(dirname($path) ?: '/');
 
 		// Recursively delete a directory. Get ready for some funky timeouts, LOL
 		if ($info->type === 'dir')
@@ -598,7 +648,14 @@ class S3Filesystem implements AdapterInterface
 
 		try
 		{
-			$meta  = $this->connector->headObject($this->bucket, $path);
+			$meta = $this->getCacheController()->get(
+				function ($path) {
+					return $this->connector->headObject($this->bucket, $path);
+				},
+				$path,
+				$this->getCacheId($path, 'head')
+			);
+
 			$found = true;
 		}
 		catch (CannotGetFile $e)
@@ -611,7 +668,14 @@ class S3Filesystem implements AdapterInterface
 		{
 			try
 			{
-				$meta  = $this->connector->headObject($this->bucket, $path . '/');
+				$meta = $this->getCacheController()->get(
+					function ($path) {
+						return $this->connector->headObject($this->bucket, $path);
+				},
+					$path . '/',
+					$this->getCacheId($path, 'head')
+				);
+
 				$isDir = true;
 			}
 			catch (CannotGetFile $e)
@@ -625,15 +689,14 @@ class S3Filesystem implements AdapterInterface
 		$ext          = File::getExt(basename(rtrim($path, '/')));
 		$meta['type'] = ($meta['type'] ?? null) === 'application/octet-stream' ? null : ($meta['type'] ?? null);
 		$timeTemp     = $meta['time'] ?? null;
-		$x            = $this->dirListingToJoomlaObject([
+
+		return $this->dirListingToJoomlaObject([
 			$nameKey => rtrim($path, '/'),
-			'time'   => is_numeric($timeTemp) ? (int)$timeTemp : time(),
+			'time'   => is_numeric($timeTemp) ? (int) $timeTemp : time(),
 			'hash'   => $meta['hash'] ?? null,
 			'type'   => $meta['type'] ?? self::MIME_TYPES[$ext] ?? 'application/octet-stream',
 			'size'   => (int) ($meta['size'] ?? 0),
 		], $dirPrefix);
-
-		return $x;
 	}
 
 	/**
@@ -691,7 +754,13 @@ class S3Filesystem implements AdapterInterface
 		{
 			try
 			{
-				$singularFile = $this->getFile($path);
+				$singularFile = $this->getCacheController()->get(
+					function($path) {
+						return $this->getFile($path);
+					},
+					$path,
+					$this->getCacheId($path)
+				);
 
 				if ($singularFile->type === 'file')
 				{
@@ -704,44 +773,53 @@ class S3Filesystem implements AdapterInterface
 			}
 		}
 
-		$dirPrefix = $this->directory . (empty($this->directory) ? '' : '/');
-		$path      = trim($path, '/');
-		$path      = $dirPrefix . $path . '/';
-		$path      = substr($path, -2) === '//' ? substr($path, 0, -1) : $path;
-		$path      = ($path === '/') ? null : $path;
-		$marker    = null;
-		$listing   = [];
-
-		do
-		{
-			$sublisting = $this->connector->getBucket($this->bucket, $path, $marker, 1000, '/', true);
-
-			if (empty($sublisting))
+		$listing = $this->getCacheController()->get(
+			function($path)
 			{
-				break;
-			}
+				$dirPrefix = $this->directory . (empty($this->directory) ? '' : '/');
+				$path      = trim($path, '/');
+				$path      = $dirPrefix . $path . '/';
+				$path      = substr($path, -2) === '//' ? substr($path, 0, -1) : $path;
+				$path      = ($path === '/') ? null : $path;
+				$marker    = null;
+				$listing   = [];
 
-			$listing = array_merge($listing, array_map(function ($raw) use ($dirPrefix) {
-				return $this->dirListingToJoomlaObject($raw, $dirPrefix);
-			}, $sublisting));
+				do
+				{
+					$sublisting = $this->connector->getBucket($this->bucket, $path, $marker, 1000, '/', true);
 
-			if (count($sublisting) < 1000)
-			{
-				break;
-			}
+					if (empty($sublisting))
+					{
+						break;
+					}
 
-			$filenames = array_keys($sublisting);
-			$marker    = array_pop($filenames);
-		} while (true);
+					$listing = array_merge($listing, array_map(function ($raw) use ($dirPrefix) {
+						return $this->dirListingToJoomlaObject($raw, $dirPrefix);
+					}, $sublisting));
 
-		$listing = array_filter(
-			array_values($listing),
-			function (object $item) {
-				return !empty($item->name ?? '');
-			}
+					if (count($sublisting) < 1000)
+					{
+						break;
+					}
+
+					$filenames = array_keys($sublisting);
+					$marker    = array_pop($filenames);
+				} while (true);
+
+				$listing = array_filter(
+					array_values($listing),
+					function (object $item) {
+						return !empty($item->name ?? '');
+					}
+				);
+
+				return array_values($listing);
+			},
+			$path,
+			$this->getCacheId($path, 'bucket')
 		);
 
-		return array_values($listing);
+		return $listing;
 	}
 
 	/**
@@ -812,7 +890,13 @@ class S3Filesystem implements AdapterInterface
 
 		try
 		{
-			$sourceInfo = $this->getFile($sourcePath);
+			$sourceInfo = $this->getCacheController()->get(
+				function ($sourcePath) {
+					return $this->getFile($sourcePath);
+				},
+				$sourcePath,
+				$this->getCacheId($sourcePath)
+			);
 			$isDir      = $sourceInfo->type === 'dir';
 		}
 		catch (FileNotFoundException $e)
@@ -824,6 +908,9 @@ class S3Filesystem implements AdapterInterface
 		// Recursively move the files of a folder
 		if ($isDir)
 		{
+			$this->uncacheDirectory($sourcePath);
+			$this->uncacheDirectory($destinationPath);
+
 			$files = $this->getFiles($sourcePath);
 
 			foreach ($files as $file)
@@ -1123,5 +1210,77 @@ class S3Filesystem implements AdapterInterface
 		}
 
 		return $name;
+	}
+
+	/**
+	 * Returns a Joomla callback cache controller.
+	 *
+	 * Used to cache the fetched toot information.
+	 *
+	 * @return  CallbackController
+	 * @throws  Exception
+	 * @since   1.0.2
+	 */
+	private function getCacheController(): CallbackController
+	{
+		if ($this->cacheController instanceof CallbackController)
+		{
+			return $this->cacheController;
+		}
+
+		$app = Factory::getApplication();
+
+		$options = [
+			'defaultgroup' => 'plg_filesystem_s3',
+			'cachebase'    => $app->get('cache_path', JPATH_CACHE),
+			'lifetime'     => $this->cacheLifetime,
+			'language'     => $app->get('language', 'en-GB'),
+			'storage'      => $app->get('cache_handler', 'file'),
+			'locking'      => true,
+			'locktime'     => 15,
+			'checkTime'    => true,
+			'caching'      => $this->cachingEnabled,
+
+		];
+
+		return $this->cacheController = Factory::getContainer()
+			->get(CacheControllerFactoryInterface::class)
+			->createCacheController('callback', $options);
+	}
+
+	/**
+	 * Returns the cache ID for a specific S3 path.
+	 *
+	 * @param   string  $path       The S3 path.
+	 * @param   string  $operation  The operation we are interested in (head, get, ...)
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0.2
+	 */
+	private function getCacheId(string $path, string $operation = 'get'): string
+	{
+		$path = trim($path, '/') ?: '/';
+
+		return md5('plg_filesystem_s3:' . $this->cacheSalt . ':' . trim($path, '/') . ':' . strtolower($operation));
+	}
+
+	/**
+	 * Remove any cached requests for a given directory
+	 *
+	 * @param   string  $path  The path to remove from the cache
+	 *
+	 * @throws  Exception
+	 * @since   1.0.2
+	 */
+	private function uncacheDirectory(string $path): void
+	{
+		$path = trim($path, '/') ?: '/';
+
+		$cache = $this->getCacheController()->cache;
+
+		$cache->remove($this->getCacheId($path, 'get'));
+		$cache->remove($this->getCacheId($path, 'head'));
+		$cache->remove($this->getCacheId($path, 'bucket'));
 	}
 }


### PR DESCRIPTION
Adds a local cache (using Joomla's cache infrastructure) for Amazon S3 API requests. This speeds up the display of the Media Manager interface by several seconds per folder.