### PR TITLE
Fix Custom Endpoint URL mapping for customcdn connection type

### DIFF
--- a/plugins/filesystem/s3/src/Adapter/S3Filesystem.php
+++ b/plugins/filesystem/s3/src/Adapter/S3Filesystem.php
@@ -444,7 +444,7 @@ class S3Filesystem implements AdapterInterface
 			'accessKey'            => $accessKey,
 			'bucket'               => $connection['bucket'] ?? '',
 			'cdnUrl'               => $isCDN ? ($cdnUrl) : null,
-			'customEndpoint'       => $type === 'custom' ? $connection['customendpoint'] : null,
+			'customEndpoint'       => in_array($type, ['custom', 'customcdn']) ? $connection['customendpoint'] : null,
 			'directory'            => $connection['directory'] ?? '',
 			'dualStack'            => ($connection['dualstack'] ?? '1') === '1',
 			'isCDN'                => $isCDN,


### PR DESCRIPTION
Pull Request for Issue #22.

### Summary of Changes
When selecting the "Custom S3-compatible CDN provider" (`customcdn`), the `$setup` array assigned `null` to the `customEndpoint` because it only checked for `$type === 'custom'`. 
This PR changes the condition to `in_array($type, ['custom', 'customcdn'])` so the endpoint is correctly used for CDN providers.

### Testing Instructions
1. Create a connection with "Custom S3-compatible CDN provider" selected.
2. Enter a Custom Endpoint URL (e.g. Cloudflare R2), Access Key, Secret Key, and CDN URL.
3. Save and open the Media Manager for this connection.

### Result before applying PR
Connection fails. The plugin falls back to `s3.dualstack.custom.amazonaws.com` because the custom endpoint is ignored.

### Result after applying PR
Connection is successful. The plugin correctly uses the provided custom endpoint for backend API calls while serving images via the CDN URL.

### Backwards compatibility
No impact.