### PR TITLE
Update Joomla HTTP dependency and minimum Joomla version to 4.4.0

### DIFF
--- a/plugins/filesystem/s3/script.plg_filesystem_s3.php
+++ b/plugins/filesystem/s3/script.plg_filesystem_s3.php
@@ -16,7 +16,7 @@ class plgFilesystemS3InstallerScript extends InstallerScript
 {
 	protected $minimumPhp = '7.4.0';
 
-	protected $minimumJoomla = '4.3.0';
+	protected $minimumJoomla = '4.4.0';
 
 	protected $allowDowngrades = true;
 

--- a/plugins/filesystem/s3/src/Helper/Ec2Metadata.php
+++ b/plugins/filesystem/s3/src/Helper/Ec2Metadata.php
@@ -9,7 +9,7 @@ namespace Akeeba\Plugin\Filesystem\S3\Helper;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Http\HttpFactory;
+use Joomla\Http\HttpFactory;
 
 /**
  * Helper class to retrieve temporary credentials from EC2 instance metadata service (IMDSv2)
@@ -98,7 +98,7 @@ class Ec2Metadata
 
 		try
 		{
-			$http     = HttpFactory::getHttp();
+			$http     = (new HttpFactory())->getHttp();
 			$response = $http->put(
 				$url,
 				'',
@@ -138,7 +138,7 @@ class Ec2Metadata
 
 		try
 		{
-			$http     = HttpFactory::getHttp();
+			$http     = (new HttpFactory())->getHttp();
 			$response = $http->get(
 				$url,
 				[
@@ -179,7 +179,7 @@ class Ec2Metadata
 
 		try
 		{
-			$http     = HttpFactory::getHttp();
+			$http     = (new HttpFactory())->getHttp();
 			$response = $http->get(
 				$url,
 				[


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes

- Updated `Ec2Metadata.php` to use `Joomla\Http\HttpFactory` instead of the deprecated `Joomla\CMS\Http\HttpFactory`
- Changed `HttpFactory::getHttp()` static calls to instance-based calls `(new HttpFactory())->getHttp()` to align with Joomla's HTTP factory API changes
- Bumped minimum Joomla version requirement from 4.3.0 to 4.4.0 in the plugin install script

### Testing Instructions

- Verify the plugin installs successfully on Joomla 4.4.0+
- Test EC2 IAM role credential retrieval (if applicable) to ensure the HTTP factory changes work correctly with IMDSv2 requests
- Confirm the plugin rejects installation on Joomla versions below 4.4.0

### Result before applying PR

Plugin uses deprecated Joomla CMS HTTP factory class and static method calls that may not be compatible with Joomla 4.4.0+.

### Result after applying PR

Plugin uses the correct Joomla HTTP factory namespace and instance-based API calls compatible with Joomla 4.4.0+. Minimum version requirement is enforced at installation time.

### Backwards compatibility

**Breaking change**: Minimum Joomla version is now 4.4.0. Installations on Joomla 4.3.x will be blocked during plugin installation/update.

https://claude.ai/code/session_01NrLDDEv26hTfRfRKMAteE7